### PR TITLE
breadcrumb URL change in budget main page

### DIFF
--- a/current_budget.php
+++ b/current_budget.php
@@ -69,7 +69,7 @@ $(document).ready(function() {
 
 <div id="content">
   <div id="utility_line" class="clearfix">
-    <div id="breadcrumb"><a href="http://energy.gov/eere/office-energy-efficiency-renewable-energy">EERE</a> &raquo; <a href="<?php echo EXT_DIR_PREFIX; ?><?php echo SITE_HOME_URL; ?>"><?php echo $strProgramName;?></a>  <a href="<?php echo EXT_DIR_PREFIX; ?><?php echo WEB_ROOT; ?>/oe_main.html" style="display:none;">About</a></div>
+    <div id="breadcrumb"><a href="http://energy.gov/eere/office-energy-efficiency-renewable-energy">EERE</a> &raquo; <a href="http://energy.gov/eere/about-us"><?php echo $strProgramName;?></a>  <a href="<?php echo EXT_DIR_PREFIX; ?><?php echo WEB_ROOT; ?>/oe_main.html" style="display:none;">About</a></div>
 
     <ul id="utilities_508" class="nositemap">
       <!--<li id="print"><a id="printversion" href="#">Printable Version</a></li>-->


### PR DESCRIPTION
updated the "Office of EERE" breadcrumb URL pointing to "About Us" in Energy.Gov
